### PR TITLE
Fix webpack externals regex

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
     ],
   },
   target: 'web',
-  externals: /k6(\/.*)?/,
+  externals: /^k6(\/.*)?/,
   stats: {
     colors: true,
   },


### PR DESCRIPTION
## What does this PR do?

I have modified the regular expression for webpack externals.
Currently, this regex is for `k6` and `k6/http`, and it is better to have the condition that the name starts with `k6`.

## Why is it important?

For example, if you start this template with the name `prefix-k6/`, without this condition, all modules will not be bundled.